### PR TITLE
Max listeners exceeded warning redis fix for queues

### DIFF
--- a/lib/helpers/redis.js
+++ b/lib/helpers/redis.js
@@ -22,6 +22,15 @@ class Helper {
         this._init = true;
     }
 
+    updateMaxListeners(clientMaxListeners, subscriberMaxListeners) {
+        if (this._client && clientMaxListeners) {
+            this._client.setMaxListeners(clientMaxListeners);
+        }
+        if (this._subscriber && subscriberMaxListeners) {
+            this._subscriber.setMaxListeners(subscriberMaxListeners);
+        }
+    }
+
     get client() {
         return this._redisOptions;
     }

--- a/lib/producer/producer.js
+++ b/lib/producer/producer.js
@@ -130,6 +130,7 @@ class Producer extends EventEmitter {
         const prefix = jobPrefix || this._setting.prefix;
         let queue = this._queues.get(jobType);
         if (!queue) {
+            redis.updateMaxListeners(this._queues.size + 1, this._queues.size + 1);
             queue = new Queue(jobType, { ...this._setting, prefix });
             queue.on('global:waiting', (jobId) => {
                 const job = this._jobMap.get(jobId);


### PR DESCRIPTION
Related Issue:  kube-HPC/hkube#1737

Issue Solved:
In: `node_modules > @hkube > bull > lib > queue.js`
We are registering listeners. This happens every time the algorithm-operator pod starts. The flow of events is as follows:
1 - `bootstrap.js` starts and initializes every module.
2 - When the `jobsMessageQueue` module initializes, it creates a new Producer.
3 - The Producer initializes Redis. On Redis initialization, MaxListeners is set to 10 by default.
4 - `jobsMessageQueue` uses the Producer to create a queue for each algorithm (by algorithm name).
5 - Every queue sets 4 different listeners named: 'error' (two different ones, one for the client and one for the subscriber), 'pmessage', and 'message' (both for the subscriber).
6 - Since we have more than 10 algorithms, a warning message is logged.

Solution: Raise the 'MaxListeners' to the number of algorithms we currently have in our system.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kube-HPC/producer-consumer.hkube/32)
<!-- Reviewable:end -->
