### PR TITLE
Max listeners exceeded warning redis in queues - improved fix

### DIFF
--- a/lib/producer/producer.js
+++ b/lib/producer/producer.js
@@ -130,7 +130,6 @@ class Producer extends EventEmitter {
         const prefix = jobPrefix || this._setting.prefix;
         let queue = this._queues.get(jobType);
         if (!queue) {
-            redis.updateMaxListeners(this._queues.size + 1, this._queues.size + 1);
             queue = new Queue(jobType, { ...this._setting, prefix });
             queue.on('global:waiting', (jobId) => {
                 const job = this._jobMap.get(jobId);

--- a/lib/producer/producer.js
+++ b/lib/producer/producer.js
@@ -190,6 +190,10 @@ class Producer extends EventEmitter {
         return queue;
     }
 
+    updateMaxRedisListeners(amountOfListeners) {
+        redis.updateMaxListeners(amountOfListeners);
+    }
+
     _shouldResolveOnCreate(options) {
         return !options.resolveOnStart && !options.resolveOnComplete;
     }


### PR DESCRIPTION
Previously, in PR: #32  I've managed to raise the number of max listeners every time an algorithm is added.
The previous solution had a minor problem - the number of max listeners isn't decreasing when an algorithm is deleted.
Instead of the previous solution, the max listeners will be updated to the amount of the current amount of algorithms.
Issue: kube-HPC/hkube#1737

The fix of the problem is related to this PR: https://github.com/kube-HPC/hkube/pull/1948

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kube-HPC/producer-consumer.hkube/33)
<!-- Reviewable:end -->
