### PR TITLE
Fixed - MaxListeners warning

### DIFF
--- a/lib/producer/producer.js
+++ b/lib/producer/producer.js
@@ -191,7 +191,7 @@ class Producer extends EventEmitter {
     }
 
     updateMaxRedisListeners(amountOfListeners) {
-        redis.updateMaxListeners(amountOfListeners);
+        redis.updateMaxListeners(amountOfListeners, amountOfListeners);
     }
 
     _shouldResolveOnCreate(options) {


### PR DESCRIPTION
Warnings are written again into logs since an argument value was not defined, now fixed.
Issue: kube-HPC/hkube#1737

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kube-HPC/producer-consumer.hkube/34)
<!-- Reviewable:end -->
